### PR TITLE
ADS1115 feature - ANA:HIRES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ add_executable(pico_scpi_usbtmc_labtool
         $ENV{SCPI_LIB_PATH}/src/utils.c
         $ENV{SCPI_LIB_PATH}/src/units.c
         $ENV{SCPI_LIB_PATH}/src/fifo.c
-        )
+        source/adc16/adc16_utils.c source/adc16/adc16_utils.h)
 
 target_include_directories(pico_scpi_usbtmc_labtool PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/source
@@ -48,7 +48,7 @@ target_include_directories(pico_scpi_usbtmc_labtool PRIVATE
         $ENV{SCPI_LIB_PATH}/inc
 )
 
-target_link_libraries(pico_scpi_usbtmc_labtool PUBLIC pico_stdlib tinyusb_device tinyusb_board hardware_gpio hardware_adc hardware_pwm)
+target_link_libraries(pico_scpi_usbtmc_labtool PUBLIC pico_stdlib tinyusb_device tinyusb_board hardware_gpio hardware_adc hardware_pwm hardware_i2c)
 pico_add_extra_outputs(pico_scpi_usbtmc_labtool)
 
 # usb output, uart output

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ add_executable(pico_scpi_usbtmc_labtool
         ${CMAKE_CURRENT_SOURCE_DIR}/source/usb/usbtmc_app.c
         ${CMAKE_CURRENT_SOURCE_DIR}/source/scpi/scpi-def.c
         ${CMAKE_CURRENT_SOURCE_DIR}/source/gpio/gpio_utils.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/source/adc/adc_utils.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/source/pwm/pwm_utils.c
         $ENV{SCPI_LIB_PATH}/src/parser.c
         $ENV{SCPI_LIB_PATH}/src/lexer.c
         $ENV{SCPI_LIB_PATH}/src/error.c
@@ -41,10 +43,12 @@ target_include_directories(pico_scpi_usbtmc_labtool PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/source/usb
         ${CMAKE_CURRENT_LIST_DIR}/source/scpi
         ${CMAKE_CURRENT_LIST_DIR}/source/gpio
+        ${CMAKE_CURRENT_LIST_DIR}/source/adc
+        ${CMAKE_CURRENT_LIST_DIR}/source/pwm
         $ENV{SCPI_LIB_PATH}/inc
 )
 
-target_link_libraries(pico_scpi_usbtmc_labtool PUBLIC pico_stdlib tinyusb_device tinyusb_board)
+target_link_libraries(pico_scpi_usbtmc_labtool PUBLIC pico_stdlib tinyusb_device tinyusb_board hardware_adc hardware_pwm)
 pico_add_extra_outputs(pico_scpi_usbtmc_labtool)
 
 # usb output, uart output

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(pico_scpi_usbtmc_labtool
         ${CMAKE_CURRENT_SOURCE_DIR}/source/scpi/scpi-def.c
         ${CMAKE_CURRENT_SOURCE_DIR}/source/gpio/gpio_utils.c
         ${CMAKE_CURRENT_SOURCE_DIR}/source/adc/adc_utils.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/source/adc16/adc16_utils.c
         ${CMAKE_CURRENT_SOURCE_DIR}/source/pwm/pwm_utils.c
         $ENV{SCPI_LIB_PATH}/src/parser.c
         $ENV{SCPI_LIB_PATH}/src/lexer.c
@@ -36,7 +37,7 @@ add_executable(pico_scpi_usbtmc_labtool
         $ENV{SCPI_LIB_PATH}/src/utils.c
         $ENV{SCPI_LIB_PATH}/src/units.c
         $ENV{SCPI_LIB_PATH}/src/fifo.c
-        source/adc16/adc16_utils.c source/adc16/adc16_utils.h)
+        )
 
 target_include_directories(pico_scpi_usbtmc_labtool PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/source
@@ -44,6 +45,7 @@ target_include_directories(pico_scpi_usbtmc_labtool PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/source/scpi
         ${CMAKE_CURRENT_LIST_DIR}/source/gpio
         ${CMAKE_CURRENT_LIST_DIR}/source/adc
+        ${CMAKE_CURRENT_LIST_DIR}/source/adc16
         ${CMAKE_CURRENT_LIST_DIR}/source/pwm
         $ENV{SCPI_LIB_PATH}/inc
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ target_include_directories(pico_scpi_usbtmc_labtool PRIVATE
         $ENV{SCPI_LIB_PATH}/inc
 )
 
-target_link_libraries(pico_scpi_usbtmc_labtool PUBLIC pico_stdlib tinyusb_device tinyusb_board hardware_adc hardware_pwm)
+target_link_libraries(pico_scpi_usbtmc_labtool PUBLIC pico_stdlib tinyusb_device tinyusb_board hardware_gpio hardware_adc hardware_pwm)
 pico_add_extra_outputs(pico_scpi_usbtmc_labtool)
 
 # usb output, uart output

--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ If you use VSCode: Preferences -> User -> Extensions -> CMake Tools -> CMake: Co
 PICO_SDK_PATH (e.g.: C:/Users/jancu/Documents/Pico/pico-sdk)  
 SCPI_LIB_PATH (e.g.: C:/Users/jancu/Documents/elektronica/scpi/scpi-parser/libscpi)
 
+[documentation] on GitHub wiki(https://github.com/jancumps/pico_scpi_usbtmc_labtool/wiki)

--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ If you use VSCode: Preferences -> User -> Extensions -> CMake Tools -> CMake: Co
 PICO_SDK_PATH (e.g.: C:/Users/jancu/Documents/Pico/pico-sdk)  
 SCPI_LIB_PATH (e.g.: C:/Users/jancu/Documents/elektronica/scpi/scpi-parser/libscpi)
 
-[documentation] on GitHub wiki(https://github.com/jancumps/pico_scpi_usbtmc_labtool/wiki)
+[documentation](https://github.com/jancumps/pico_scpi_usbtmc_labtool/wiki) on GitHub wiki

--- a/source/adc/adc_utils.c
+++ b/source/adc/adc_utils.c
@@ -4,7 +4,7 @@
 
 /*
 ADC0	GP26
-ADC1	GP27 // used fore button on the pico-eurocard
+ADC1	GP27 // used for button on the pico-eurocard
 ADC2	GP28
 */
 

--- a/source/adc/adc_utils.c
+++ b/source/adc/adc_utils.c
@@ -4,23 +4,32 @@
 
 /*
 ADC0	GP26
-ADC1	GP27
+ADC1	GP27 // used fore button on the pico-eurocard
 ADC2	GP28
 */
 
+// supported pins
+uint adcPins[][2] = {
+    {0,26}, 
+    // {1,27}, // this is used for the button on the eurocard.
+    {2,28}
+};
+
+void initAdcUtils() {
+    adc_init();
+}
 
 uint32_t adcPinCount() {
-    // TODO implement
-    return 0;
+    return sizeof(adcPins)/(sizeof(adcPins[0][0])+sizeof(adcPins[0][1]));
 }
 
 void initAdcPins() {
-    // TODO implement
-    return;
-
+    for (uint32_t i = 0; i < adcPinCount(); i++) {
+        adc_gpio_init(adcPins[i][1]); // the gpio pin is needed here
+    }
 }
 
-uint32_t getAdcPinAt(uint32_t index) {
-    // TODO implement
-    return 0;
+uint16_t getAdcPinAt(uint32_t index) {
+      adc_select_input(adcPins[index][0]); // the ADC pin number is needed here
+      return adc_read();
 }

--- a/source/adc/adc_utils.c
+++ b/source/adc/adc_utils.c
@@ -1,0 +1,26 @@
+#include "hardware/adc.h"
+
+#include "adc_utils.h"
+
+/*
+ADC0	GP26
+ADC1	GP27
+ADC2	GP28
+*/
+
+
+uint32_t adcPinCount() {
+    // TODO implement
+    return 0;
+}
+
+void initAdcPins() {
+    // TODO implement
+    return;
+
+}
+
+uint32_t getAdcPinAt(uint32_t index) {
+    // TODO implement
+    return 0;
+}

--- a/source/adc/adc_utils.h
+++ b/source/adc/adc_utils.h
@@ -1,9 +1,9 @@
 #ifndef _ADC_UTILS_H
 #define _ADC_UTILS_H
 
-
+void initAdcUtils();
 uint32_t adcPinCount();
 void initAdcPins();
-uint32_t getAdcPinAt(uint32_t index);
+uint16_t getAdcPinAt(uint32_t index);
 
 #endif // _ADC_UTILS_H

--- a/source/adc/adc_utils.h
+++ b/source/adc/adc_utils.h
@@ -1,0 +1,9 @@
+#ifndef _ADC_UTILS_H
+#define _ADC_UTILS_H
+
+
+uint32_t adcPinCount();
+void initAdcPins();
+uint32_t getAdcPinAt(uint32_t index);
+
+#endif // _ADC_UTILS_H

--- a/source/adc16/adc16_utils.c
+++ b/source/adc16/adc16_utils.c
@@ -12,7 +12,7 @@ SDA: GP4
 
 /************** global vars ***************/
 uint8_t adc16Installed = 0;
-uint8_t adc16Channel = 0;
+uint32_t adc16Channel = 0;
 uint8_t confreg[2]; // config register
 
 /************** functions *****************/
@@ -102,29 +102,13 @@ uint32_t adc16PinCount() {
 
 // get ADC result from the ADS1115
 uint16_t getAdc16PinAt(uint32_t index) {
-    uint8_t muxval;
     uint16_t res;
-    if (adc16Channel == (uint8_t)index) {
+    if (adc16Channel == index) {
         // already set to this channel
     } else {
         // switch channel, and then wait for a conversion to be done
-        switch (index) {
-            case 0:
-                muxval = ADS1115_CH0;
-                break;
-            case 1:
-                muxval = ADS1115_CH1;
-                break;
-            case 2:
-                muxval = ADS1115_CH2;
-                break;
-            case 3:
-                muxval = ADS1115_CH3;
-                break;
-            default:
-                break;
-        }
-        setAdc16Mux(muxval);
+        adc16Channel = index;
+        setAdc16Mux(ADS1115_CH0 + index);
         // no need to start conversion, since we are in continuous conversion mode
         sleep_ms(150); // wait for conversion to complete
     }

--- a/source/adc16/adc16_utils.c
+++ b/source/adc16/adc16_utils.c
@@ -57,7 +57,8 @@ void setAdc16Mux(uint8_t mux) {
     i2c_write_blocking(i2c_default, ADS_ADDR, buf, 3, false);
 }
 
-// start a conversion
+// start a conversion (this is only for single-shot mode)
+// will delete this function if it's not needed
 void startAdc16Conv(void) {
     uint8_t buf[3];
     buf[0] = ADS1115_REG_CONFIG;
@@ -66,7 +67,8 @@ void startAdc16Conv(void) {
     i2c_write_blocking(i2c_default, ADS_ADDR, buf, 3, false);
 }
 
-// check if the conversion is complete
+// check if the conversion is complete (this may only work for single-shot mode)
+// will delete this function if it's not needed
 uint8_t adc16ConvDone(void) {
     uint8_t buf[3];
     buf[0] = ADS1115_REG_CONFIG;
@@ -123,9 +125,10 @@ uint16_t getAdc16PinAt(uint32_t index) {
                 break;
         }
         setAdc16Mux(muxval);
-        startAdc16Conv();
+        // no need to start conversion, since we are in continuous conversion mode
         sleep_ms(150); // wait for conversion to complete
     }
     res = readAdc16Meas();
+    // no need to start another conversion, since we are in continuous conversion mode
     return(res);
 }

--- a/source/adc16/adc16_utils.c
+++ b/source/adc16/adc16_utils.c
@@ -84,12 +84,14 @@ uint8_t adc16ConvDone(void) {
 
 // read the conversion register
 uint16_t readAdc16Meas(void) {
+    uint16_t meas;
     uint16_t buf;
     uint8_t* buf8_ptr = (uint8_t*)&buf;
     *buf8_ptr = ADS1115_REG_CONVERSION;
-    i2c_write_blocking(i2c_default, ADS_ADDR, buf8_ptr, 1, true);
+    i2c_write_blocking(i2c_default, ADS_ADDR, buf8_ptr, 1, false);
     i2c_read_blocking(i2c_default, ADS_ADDR, buf8_ptr, 2, false);
-    return(buf);
+    meas = buf>>8 | buf<<8; // swap bytes
+    return(meas);
 }
 
 // provide a pin count. returns 0 if the ADS1115 is not installed

--- a/source/adc16/adc16_utils.c
+++ b/source/adc16/adc16_utils.c
@@ -1,0 +1,45 @@
+#include "adc16_utils.h"
+#include "hardware/gpio.h"
+#include "hardware/i2c.h"
+
+
+/*
+ADC16 uses the I2C bus to communicate with the ASD1115 chip.
+The I2C bus is connected to the following pins:
+SCL: GP5
+SDA: GP4
+*/
+
+/************** global vars ***************/
+uint8_t confreg[2]; // config register
+
+/************** functions *****************/
+// initialize the I2C bus
+void initAdc16I2C(void) {
+    i2c_init(i2c_default, 10000); // I2C0 on GPIO 4[SDA],5[SCL]
+    gpio_set_function(PICO_DEFAULT_I2C_SDA_PIN, GPIO_FUNC_I2C);
+    gpio_set_function(PICO_DEFAULT_I2C_SCL_PIN, GPIO_FUNC_I2C);
+    gpio_pull_up(PICO_DEFAULT_I2C_SDA_PIN); // weak pull-ups but enable them anyway
+    gpio_pull_up(PICO_DEFAULT_I2C_SCL_PIN);
+}
+
+// initialize the ADS1115 registers
+void initAdc16Reg(void) {
+    uint8_t buf[3];
+    confreg[0] = 0x44; // MUX set to AIN0, and PGA set to +-2.048V and Continuous Conversion mode
+    confreg[1] = 0x03; // rate = 8 SPS
+    buf[0] = ADS1115_REG_CONFIG;
+    buf[1] = confreg[0];
+    buf[2] = confreg[1];
+    i2c_write_blocking(i2c_default, ADS_ADDR, buf, 3, false);
+}
+
+// read the conversion register
+uint16_t readAdc16Meas(void) {
+    uint16_t buf;
+    uint8_t* buf8_ptr = (uint8_t*)&buf;
+    *buf8_ptr = ADS1115_REG_CONVERSION;
+    i2c_write_blocking(i2c_default, ADS_ADDR, buf8_ptr, 1, true);
+    i2c_read_blocking(i2c_default, ADS_ADDR, buf8_ptr, 2, false);
+    return(buf);
+}

--- a/source/adc16/adc16_utils.c
+++ b/source/adc16/adc16_utils.c
@@ -40,7 +40,7 @@ void initAdc16Reg(void) {
     }
     // set config register to desired values
     confreg[0] = 0x44; // MUX set to AIN0, and PGA set to +-2.048V and continuous conversion mode
-    confreg[1] = 0x03; // rate = 8 SPS
+    confreg[1] = 0x43; // rate = 32 SPS
     buf[0] = ADS1115_REG_CONFIG;
     buf[1] = confreg[0];
     buf[2] = confreg[1];

--- a/source/adc16/adc16_utils.c
+++ b/source/adc16/adc16_utils.c
@@ -41,6 +41,7 @@ void initAdc16Reg(void) {
     // set config register to desired values
     confreg[0] = 0x44; // MUX set to AIN0, and PGA set to +-2.048V and continuous conversion mode
     confreg[1] = 0x03; // rate = 8 SPS
+    buf[0] = ADS1115_REG_CONFIG;
     buf[1] = confreg[0];
     buf[2] = confreg[1];
     i2c_write_blocking(i2c_default, ADS_ADDR, buf, 3, false);

--- a/source/adc16/adc16_utils.h
+++ b/source/adc16/adc16_utils.h
@@ -12,10 +12,18 @@
 #define ADS1115_REG_CONFIG 0x01
 #define ADS1115_REG_LO_THRESH 0x02
 #define ADS1115_REG_HI_THRESH 0x03
+// ADS1115 mux values
+#define ADS1115_CH0 0x04
+#define ADS1115_CH1 0x05
+#define ADS1115_CH2 0x06
+#define ADS1115_CH3 0x07
+#define ADS1115_DIFF_0_1 0x00
+#define ADS1115_DIFF_2_3 0x11
 
 /******* functions *********/
 void initAdc16I2C(void);
 void initAdc16Reg(void);
-uint16_t readAdc16Meas(void);
+uint32_t adc16PinCount();
+uint16_t getAdc16PinAt(uint32_t index);
 
 #endif // _ADC16_UTILS_H

--- a/source/adc16/adc16_utils.h
+++ b/source/adc16/adc16_utils.h
@@ -1,0 +1,21 @@
+#ifndef _ADC16_UTILS_H
+#define _ADC16_UTILS_H
+
+/********** includes **********/
+#include "pico/stdlib.h"
+
+/******* defines *********************/
+// ADS1115 ADDR pin set to 0V results in I2C address 0x48
+#define ADS_ADDR 0x48
+// ADS1115 registers (4)
+#define ADS1115_REG_CONVERSION 0x00
+#define ADS1115_REG_CONFIG 0x01
+#define ADS1115_REG_LO_THRESH 0x02
+#define ADS1115_REG_HI_THRESH 0x03
+
+/******* functions *********/
+void initAdc16I2C(void);
+void initAdc16Reg(void);
+uint16_t readAdc16Meas(void);
+
+#endif // _ADC16_UTILS_H

--- a/source/gpio/gpio_utils.c
+++ b/source/gpio/gpio_utils.c
@@ -11,6 +11,10 @@ uint outPins[] = {
 
 // TODO input pins
 
+void initGpioUtils() {
+    return; // nothing needed
+}
+
 uint32_t outPinCount() {
     return sizeof(outPins)/sizeof(outPins[0]);
 }

--- a/source/gpio/gpio_utils.c
+++ b/source/gpio/gpio_utils.c
@@ -9,6 +9,7 @@ uint outPins[] = {
     if you want to use this pin, remove the led_blinking_task() */
     22, 14, 15};
 
+// TODO input pins
 
 uint32_t outPinCount() {
     return sizeof(outPins)/sizeof(outPins[0]);
@@ -30,3 +31,4 @@ bool isOutPinAt(uint32_t index) {
     return gpio_get_out_level(outPins[index]);
 }
 
+// TODO input pins

--- a/source/gpio/gpio_utils.c
+++ b/source/gpio/gpio_utils.c
@@ -4,29 +4,29 @@
 #include "gpio_utils.h"
 
 // supported pins
-uint pins[] = {
+uint outPins[] = {
     /*PICO_DEFAULT_LED_PIN, removed in this project, because the USBTMC code makes good use of it to show USB status
     if you want to use this pin, remove the led_blinking_task() */
     22, 14, 15};
 
 
-uint32_t pinCount() {
-    return sizeof(pins)/sizeof(pins[0]);
+uint32_t outPinCount() {
+    return sizeof(outPins)/sizeof(outPins[0]);
 }
 
-void initPins() {
-    for (uint32_t i = 0; i < pinCount(); i++) {
-        gpio_init(pins[i]);
-        gpio_set_dir(pins[i], 1);
-        gpio_put(pins[i], 0);
+void initOutPins() {
+    for (uint32_t i = 0; i < outPinCount(); i++) {
+        gpio_init(outPins[i]);
+        gpio_set_dir(outPins[i], 1);
+        gpio_put(outPins[i], 0);
     }
 }
 
-void setPinAt(uint32_t index, bool on) {
-    gpio_put(pins[index], on);
+void setOutPinAt(uint32_t index, bool on) {
+    gpio_put(outPins[index], on);
 }
 
-bool isPinAt(uint32_t index) {
-    return gpio_get_out_level(pins[index]);
+bool isOutPinAt(uint32_t index) {
+    return gpio_get_out_level(outPins[index]);
 }
 

--- a/source/gpio/gpio_utils.h
+++ b/source/gpio/gpio_utils.h
@@ -2,9 +2,9 @@
 #define _GPIO_UTILS_H
 
 
-uint32_t pinCount();
-void initPins();
-void setPinAt(uint32_t index, bool on);
-bool isPinAt(uint32_t index);
+uint32_t outPinCount();
+void initOutPins();
+void setOutPinAt(uint32_t index, bool on);
+bool isOutPinAt(uint32_t index);
 
 #endif // _GPIO_UTILS_H

--- a/source/gpio/gpio_utils.h
+++ b/source/gpio/gpio_utils.h
@@ -3,6 +3,7 @@
 
 
 uint32_t outPinCount();
+void initGpioUtils();
 void initOutPins();
 void setOutPinAt(uint32_t index, bool on);
 bool isOutPinAt(uint32_t index);

--- a/source/gpio/gpio_utils.h
+++ b/source/gpio/gpio_utils.h
@@ -7,4 +7,6 @@ void initOutPins();
 void setOutPinAt(uint32_t index, bool on);
 bool isOutPinAt(uint32_t index);
 
+// TODO gpio input pins
+
 #endif // _GPIO_UTILS_H

--- a/source/pwm/pwm_utils.c
+++ b/source/pwm/pwm_utils.c
@@ -1,0 +1,18 @@
+#include "hardware/pwm.h"
+
+#include "pwm_utils.h"
+
+uint32_t pwmPinCount() {
+    // TODO implement
+    return 0;
+}
+
+void initPwmPins() {
+    // TODO implement
+    return;
+}
+
+void setPwmPinAt(uint32_t index, uint32_t value)  {
+    // TODO implement
+    return;
+}

--- a/source/pwm/pwm_utils.c
+++ b/source/pwm/pwm_utils.c
@@ -2,6 +2,10 @@
 
 #include "pwm_utils.h"
 
+void initPwmUtils() {
+    // TODO pwm_init();
+}
+
 uint32_t pwmPinCount() {
     // TODO implement
     return 0;

--- a/source/pwm/pwm_utils.h
+++ b/source/pwm/pwm_utils.h
@@ -1,0 +1,9 @@
+#ifndef _PWM_UTILS_H
+#define _PWM_UTILS_H
+
+
+uint32_t pwmPinCount();
+void initPwmPins();
+void setPwmPinAt(uint32_t index, uint32_t value);
+
+#endif // _PWM_UTILS_H

--- a/source/pwm/pwm_utils.h
+++ b/source/pwm/pwm_utils.h
@@ -1,7 +1,7 @@
 #ifndef _PWM_UTILS_H
 #define _PWM_UTILS_H
 
-
+void initPwmUtils();
 uint32_t pwmPinCount();
 void initPwmPins();
 void setPwmPinAt(uint32_t index, uint32_t value);

--- a/source/scpi/scpi-def.c
+++ b/source/scpi/scpi-def.c
@@ -74,7 +74,7 @@ static scpi_result_t SCPI_DigitalOutput(scpi_t * context) {
 
   // retrieve the output index
   SCPI_CommandNumbers(context, numbers, 1, 0);
-  if (! ((numbers[0] > -1) && (numbers[0] < pinCount()))) {
+  if (! ((numbers[0] > -1) && (numbers[0] < outPinCount()))) {
     SCPI_ErrorPush(context, SCPI_ERROR_INVALID_SUFFIX);
     return SCPI_RES_ERR;
   }
@@ -84,7 +84,7 @@ static scpi_result_t SCPI_DigitalOutput(scpi_t * context) {
     return SCPI_RES_ERR;
   }
 
-  setPinAt(numbers[0], param1 ? true : false);
+  setOutPinAt(numbers[0], param1 ? true : false);
 
   return SCPI_RES_OK;
 }
@@ -94,12 +94,12 @@ static scpi_result_t SCPI_DigitalOutputQ(scpi_t * context) {
 
   // retrieve the output index
   SCPI_CommandNumbers(context, numbers, 1, 0);
-  if (! ((numbers[0] > -1) && (numbers[0] < pinCount()))) {
+  if (! ((numbers[0] > -1) && (numbers[0] < outPinCount()))) {
     SCPI_ErrorPush(context, SCPI_ERROR_INVALID_SUFFIX);
     return SCPI_RES_ERR;
   }
 
-  SCPI_ResultBool(context, isPinAt(numbers[0]));
+  SCPI_ResultBool(context, isOutPinAt(numbers[0]));
   return SCPI_RES_OK;
 }
 
@@ -147,7 +147,7 @@ scpi_t scpi_context;
 
 // init helper for this instrument
 void scpi_instrument_init() {
-    initPins(); // if you prefer no dependency on the gpio_utils in main,
+    initOutPins(); // if you prefer no dependency on the gpio_utils in main,
               // you could move this call into the scpi_instrument_init() body.
               // like I did here
     
@@ -179,6 +179,6 @@ size_t SCPI_Write(scpi_t * context, const char * data, size_t len) {
 
 scpi_result_t SCPI_Reset(scpi_t * context) {
     (void) context;
-    initPins();
+    initOutPins();
     return SCPI_RES_OK;   
 }

--- a/source/scpi/scpi-def.c
+++ b/source/scpi/scpi-def.c
@@ -216,6 +216,8 @@ void initInstrument() {
     // TODO input pins
     initAdcUtils();
     initAdcPins();
+    initAdc16I2C();
+    initAdc16Reg();
     initPwmUtils();
     initPwmPins();
 }

--- a/source/scpi/scpi-def.c
+++ b/source/scpi/scpi-def.c
@@ -52,6 +52,7 @@
 
 #include "gpio_utils.h"
 #include "adc_utils.h"
+#include "adc16_utils.h"
 #include "pwm_utils.h"
 
 #include "usbtmc_app.h"

--- a/source/scpi/scpi-def.c
+++ b/source/scpi/scpi-def.c
@@ -109,7 +109,21 @@ static scpi_result_t SCPI_DigitalOutputQ(scpi_t * context) {
 }
 
 // TODO gpio in commands
-// TODO adc commands
+
+static scpi_result_t SCPI_AnalogInputQ(scpi_t * context) {
+  int32_t numbers[1];
+
+  // retrieve the adc index
+  SCPI_CommandNumbers(context, numbers, 1, 0);
+  if (! ((numbers[0] > -1) && (numbers[0] < adcPinCount()))) {
+    SCPI_ErrorPush(context, SCPI_ERROR_INVALID_SUFFIX);
+    return SCPI_RES_ERR;
+  }
+
+  SCPI_ResultUInt16(context, getAdcPinAt(numbers[0]));
+  return SCPI_RES_OK;
+}
+
 // TODO pwm in commands
 
 const scpi_command_t scpi_commands[] = {
@@ -138,6 +152,7 @@ const scpi_command_t scpi_commands[] = {
     {.pattern = "DIGItal:OUTPut#?", .callback = SCPI_DigitalOutputQ,},
     // TODO gpio in commands
     // TODO adc commands
+    {.pattern = "ANAlog:INPut#:RAW?", .callback = SCPI_AnalogInputQ,},
     // TODO pwm in commands
     SCPI_CMD_LIST_END
 };
@@ -195,8 +210,11 @@ scpi_result_t SCPI_Reset(scpi_t * context) {
 }
 
 void initInstrument() {
+    initGpioUtils();
     initOutPins();
     // TODO input pins
+    initAdcUtils();
     initAdcPins();
+    initPwmUtils();
     initPwmPins();
 }

--- a/source/scpi/scpi-def.c
+++ b/source/scpi/scpi-def.c
@@ -125,6 +125,20 @@ static scpi_result_t SCPI_AnalogInputQ(scpi_t * context) {
   return SCPI_RES_OK;
 }
 
+static scpi_result_t SCPI_Analog16InputQ(scpi_t * context) {
+    int32_t numbers[1];
+
+    // retrieve the adc index
+    SCPI_CommandNumbers(context, numbers, 1, 0);
+    if (! ((numbers[0] > -1) && (numbers[0] < adc16PinCount()))) {
+        SCPI_ErrorPush(context, SCPI_ERROR_INVALID_SUFFIX);
+        return SCPI_RES_ERR;
+    }
+
+    SCPI_ResultUInt16(context, getAdc16PinAt(numbers[0]));
+    return SCPI_RES_OK;
+}
+
 // TODO pwm in commands
 
 const scpi_command_t scpi_commands[] = {
@@ -154,6 +168,7 @@ const scpi_command_t scpi_commands[] = {
     // TODO gpio in commands
     // TODO adc commands
     {.pattern = "ANAlog:INPut#:RAW?", .callback = SCPI_AnalogInputQ,},
+    {.pattern = "ANAlog:HIRES:INPut#:RAW?", .callback = SCPI_Analog16InputQ,},
     // TODO pwm in commands
     SCPI_CMD_LIST_END
 };

--- a/source/scpi/scpi-def.c
+++ b/source/scpi/scpi-def.c
@@ -51,7 +51,12 @@
 #include "scpi-def.h"
 
 #include "gpio_utils.h"
+#include "adc_utils.h"
+#include "pwm_utils.h"
+
 #include "usbtmc_app.h"
+
+void initInstrument();
 
 /**
  * Reimplement IEEE488.2 *TST?
@@ -103,6 +108,9 @@ static scpi_result_t SCPI_DigitalOutputQ(scpi_t * context) {
   return SCPI_RES_OK;
 }
 
+// TODO gpio in commands
+// TODO adc commands
+// TODO pwm in commands
 
 const scpi_command_t scpi_commands[] = {
     /* IEEE Mandated Commands (SCPI std V1999.0 4.1.1) */
@@ -128,6 +136,9 @@ const scpi_command_t scpi_commands[] = {
     /* custom commands for the switch */
     {.pattern = "DIGItal:OUTPut#", .callback = SCPI_DigitalOutput,},
     {.pattern = "DIGItal:OUTPut#?", .callback = SCPI_DigitalOutputQ,},
+    // TODO gpio in commands
+    // TODO adc commands
+    // TODO pwm in commands
     SCPI_CMD_LIST_END
 };
 
@@ -147,7 +158,7 @@ scpi_t scpi_context;
 
 // init helper for this instrument
 void scpi_instrument_init() {
-    initOutPins(); // if you prefer no dependency on the gpio_utils in main,
+    initInstrument(); // if you prefer no dependency on the gpio_utils in main,
               // you could move this call into the scpi_instrument_init() body.
               // like I did here
     
@@ -179,6 +190,13 @@ size_t SCPI_Write(scpi_t * context, const char * data, size_t len) {
 
 scpi_result_t SCPI_Reset(scpi_t * context) {
     (void) context;
-    initOutPins();
+    initInstrument();
     return SCPI_RES_OK;   
+}
+
+void initInstrument() {
+    initOutPins();
+    // TODO input pins
+    initAdcPins();
+    initPwmPins();
 }


### PR DESCRIPTION
This Pull Request is for a new feature, which implements a high-resolution ADC for the Pico SCPI labTool.

To use the new feature, an ADS1115 chip needs to be connected to the I2C pins (SCL:GP5, SDA:GP4) of the Pi Pico.

The new SCPI query is:

ANA:HIRES:INP#:RAW?

where # is a value [0..3].
