### PR TITLE
Shabaz adc16 feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(pico_scpi_usbtmc_labtool
         ${CMAKE_CURRENT_SOURCE_DIR}/source/scpi/scpi-def.c
         ${CMAKE_CURRENT_SOURCE_DIR}/source/gpio/gpio_utils.c
         ${CMAKE_CURRENT_SOURCE_DIR}/source/adc/adc_utils.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/source/adc16/adc16_utils.c
         ${CMAKE_CURRENT_SOURCE_DIR}/source/pwm/pwm_utils.c
         $ENV{SCPI_LIB_PATH}/src/parser.c
         $ENV{SCPI_LIB_PATH}/src/lexer.c
@@ -36,7 +37,7 @@ add_executable(pico_scpi_usbtmc_labtool
         $ENV{SCPI_LIB_PATH}/src/utils.c
         $ENV{SCPI_LIB_PATH}/src/units.c
         $ENV{SCPI_LIB_PATH}/src/fifo.c
-        )
+        source/adc16/adc16_utils.c source/adc16/adc16_utils.h)
 
 target_include_directories(pico_scpi_usbtmc_labtool PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/source
@@ -44,11 +45,12 @@ target_include_directories(pico_scpi_usbtmc_labtool PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/source/scpi
         ${CMAKE_CURRENT_LIST_DIR}/source/gpio
         ${CMAKE_CURRENT_LIST_DIR}/source/adc
+        ${CMAKE_CURRENT_LIST_DIR}/source/adc16
         ${CMAKE_CURRENT_LIST_DIR}/source/pwm
         $ENV{SCPI_LIB_PATH}/inc
 )
 
-target_link_libraries(pico_scpi_usbtmc_labtool PUBLIC pico_stdlib tinyusb_device tinyusb_board hardware_gpio hardware_adc hardware_pwm)
+target_link_libraries(pico_scpi_usbtmc_labtool PUBLIC pico_stdlib tinyusb_device tinyusb_board hardware_gpio hardware_adc hardware_pwm hardware_i2c)
 pico_add_extra_outputs(pico_scpi_usbtmc_labtool)
 
 # usb output, uart output

--- a/source/adc16/adc16_utils.c
+++ b/source/adc16/adc16_utils.c
@@ -1,0 +1,137 @@
+#include "adc16_utils.h"
+#include "hardware/gpio.h"
+#include "hardware/i2c.h"
+
+
+/*
+ADC16 uses the I2C bus to communicate with the ASD1115 chip.
+The I2C bus is connected to the following pins:
+SCL: GP5
+SDA: GP4
+
+ ADC strategy:
+ The ADC is run in continuous-conversion mode. Currently only single-ended inputs are supported,
+ enumerated as channels 0-3. The ADC is configured to measure +2.048V full-scale, at a rate of 32 SPS,
+ i.e. a new result is available every 31.25ms. Note: when switching channels, the new result won't be
+ available for about 80 msec (2 * 31.25ms, plus a small margin).
+ In single-ended mode, the raw result is a 15-bit value, i.e. 0-32767.
+ To convert to a voltage, the reported raw result can be multiplied by 2.048/32767.
+*/
+
+/************** global vars ***************/
+uint8_t adc16Installed = 0;
+uint32_t adc16Channel = 0;
+uint8_t confreg[2]; // config register
+
+/************** functions *****************/
+// initialize the I2C bus
+void initAdc16I2C(void) {
+    i2c_init(i2c_default, 10000); // I2C0 on GPIO 4[SDA],5[SCL]
+    gpio_set_function(PICO_DEFAULT_I2C_SDA_PIN, GPIO_FUNC_I2C);
+    gpio_set_function(PICO_DEFAULT_I2C_SCL_PIN, GPIO_FUNC_I2C);
+    gpio_pull_up(PICO_DEFAULT_I2C_SDA_PIN); // weak pull-ups but enable them anyway
+    gpio_pull_up(PICO_DEFAULT_I2C_SCL_PIN);
+}
+
+// initialize the ADS1115 registers
+void initAdc16Reg(void) {
+    uint8_t buf[3];
+    // is the ADC chip installed?
+    buf[0] = ADS1115_REG_CONFIG;
+    i2c_write_blocking(i2c_default, ADS_ADDR, buf, 1, false);
+    i2c_read_blocking(i2c_default, ADS_ADDR, buf, 2, false);
+    if (buf[0] != 0x85 || buf[1] != 0x83) {
+        adc16Installed = 0; // no chip found
+        return;
+    } else {
+        adc16Installed = 1; // chip found
+    }
+    // set config register to desired values
+    confreg[0] = 0x44; // MUX set to AIN0, and PGA set to +-2.048V and continuous conversion mode
+    confreg[1] = 0x43; // rate = 32 SPS
+    buf[0] = ADS1115_REG_CONFIG;
+    buf[1] = confreg[0];
+    buf[2] = confreg[1];
+    i2c_write_blocking(i2c_default, ADS_ADDR, buf, 3, false);
+}
+
+// set the multiplexer to the desired input
+void setAdc16Mux(uint8_t mux) {
+    uint8_t buf[3];
+    confreg[0] &= ~0x70; // clear the MUX bits
+    confreg[0] |= (mux<<4); // set the MUX bits
+    buf[0] = ADS1115_REG_CONFIG;
+    buf[1] = confreg[0];
+    buf[2] = confreg[1];
+    i2c_write_blocking(i2c_default, ADS_ADDR, buf, 3, false);
+}
+
+// start a conversion (this is only for single-shot mode)
+// will delete this function if it's not needed
+void startAdc16Conv(void) {
+    uint8_t buf[3];
+    buf[0] = ADS1115_REG_CONFIG;
+    buf[1] = confreg[0] | 0x80; // set 'OS' bit to start a conversion
+    buf[2] = confreg[1];
+    i2c_write_blocking(i2c_default, ADS_ADDR, buf, 3, false);
+}
+
+// check if the conversion is complete (this may only work for single-shot mode)
+// will delete this function if it's not needed
+uint8_t adc16ConvDone(void) {
+    uint8_t buf[3];
+    buf[0] = ADS1115_REG_CONFIG;
+    i2c_write_blocking(i2c_default, ADS_ADDR, buf, 1, false);
+    i2c_read_blocking(i2c_default, ADS_ADDR, buf, 2, false);
+    if (buf[0] & 0x80) {
+        return 0; // conversion not done
+    } else {
+        return 1; // conversion done
+    }
+}
+
+// read the conversion register
+uint16_t readAdc16Meas(void) {
+    uint16_t meas;
+    uint16_t buf;
+    uint8_t* buf8_ptr = (uint8_t*)&buf;
+    *buf8_ptr = ADS1115_REG_CONVERSION;
+    i2c_write_blocking(i2c_default, ADS_ADDR, buf8_ptr, 1, false);
+    i2c_read_blocking(i2c_default, ADS_ADDR, buf8_ptr, 2, false);
+    meas = buf>>8 | buf<<8; // swap bytes
+    if (adc16Channel < 4) {
+        // we are in single-ended mode. Any integer value less than 0 is invalid
+        // and since we are dealing with unsigned values, that means that any
+        // value greater than 32767 is invalid.
+        if (meas > 32767) {
+            meas = 0;
+        }
+    }
+    return(meas);
+}
+
+// provide a pin count. returns 0 if the ADS1115 is not installed
+uint32_t adc16PinCount() {
+    if (adc16Installed) {
+        return(4);
+    } else {
+        return(0);
+    }
+}
+
+// get ADC result from the ADS1115
+uint16_t getAdc16PinAt(uint32_t index) {
+    uint16_t res;
+    if (adc16Channel == index) {
+        // already set to this channel
+    } else {
+        // switch channel, and then wait for a conversion to be done
+        adc16Channel = index;
+        setAdc16Mux(ADS1115_CH0 + index);
+        // no need to start conversion, since we are in continuous conversion mode
+        sleep_ms(80); // wait for conversion to complete. The value should be 2 * (1/SPS) + margin
+    }
+    res = readAdc16Meas();
+    // no need to start another conversion, since we are in continuous conversion mode
+    return(res);
+}

--- a/source/adc16/adc16_utils.h
+++ b/source/adc16/adc16_utils.h
@@ -1,0 +1,29 @@
+#ifndef _ADC16_UTILS_H
+#define _ADC16_UTILS_H
+
+/********** includes **********/
+#include "pico/stdlib.h"
+
+/******* defines *********************/
+// ADS1115 ADDR pin set to 0V results in I2C address 0x48
+#define ADS_ADDR 0x48
+// ADS1115 registers (4)
+#define ADS1115_REG_CONVERSION 0x00
+#define ADS1115_REG_CONFIG 0x01
+#define ADS1115_REG_LO_THRESH 0x02
+#define ADS1115_REG_HI_THRESH 0x03
+// ADS1115 mux values
+#define ADS1115_CH0 0x04
+#define ADS1115_CH1 0x05
+#define ADS1115_CH2 0x06
+#define ADS1115_CH3 0x07
+#define ADS1115_DIFF_0_1 0x00
+#define ADS1115_DIFF_2_3 0x11
+
+/******* functions *********/
+void initAdc16I2C(void);
+void initAdc16Reg(void);
+uint32_t adc16PinCount();
+uint16_t getAdc16PinAt(uint32_t index);
+
+#endif // _ADC16_UTILS_H

--- a/source/scpi/scpi-def.c
+++ b/source/scpi/scpi-def.c
@@ -52,6 +52,7 @@
 
 #include "gpio_utils.h"
 #include "adc_utils.h"
+#include "adc16_utils.h"
 #include "pwm_utils.h"
 
 #include "usbtmc_app.h"
@@ -124,6 +125,20 @@ static scpi_result_t SCPI_AnalogInputQ(scpi_t * context) {
   return SCPI_RES_OK;
 }
 
+static scpi_result_t SCPI_Analog16InputQ(scpi_t * context) {
+    int32_t numbers[1];
+
+    // retrieve the adc index
+    SCPI_CommandNumbers(context, numbers, 1, 0);
+    if (! ((numbers[0] > -1) && (numbers[0] < adc16PinCount()))) {
+        SCPI_ErrorPush(context, SCPI_ERROR_INVALID_SUFFIX);
+        return SCPI_RES_ERR;
+    }
+
+    SCPI_ResultUInt16(context, getAdc16PinAt(numbers[0]));
+    return SCPI_RES_OK;
+}
+
 // TODO pwm in commands
 
 const scpi_command_t scpi_commands[] = {
@@ -153,6 +168,7 @@ const scpi_command_t scpi_commands[] = {
     // TODO gpio in commands
     // TODO adc commands
     {.pattern = "ANAlog:INPut#:RAW?", .callback = SCPI_AnalogInputQ,},
+    {.pattern = "ANAlog:HIRES:INPut#:RAW?", .callback = SCPI_Analog16InputQ,},
     // TODO pwm in commands
     SCPI_CMD_LIST_END
 };
@@ -215,6 +231,8 @@ void initInstrument() {
     // TODO input pins
     initAdcUtils();
     initAdcPins();
+    initAdc16I2C();
+    initAdc16Reg();
     initPwmUtils();
     initPwmPins();
 }


### PR DESCRIPTION
Implemented the adc16 feature, which is the ability to add an ADS1115 ADC chip/module to the Pico SCPI labTool.
If the ADS1115 is attached to the I2C connections (SCL=GP5, SDA=GP4) then it will be detected and the following commands will provide measurements for the four channels available on that chip.
The SCPI query syntax is:
ANA:HIRES:INP#:RAW?
where # is [0..3].
