### PR TITLE
Created the PWM functionality in pwm_utils.c/.h and added the SCPI co…

### DIFF
--- a/source/pwm/pwm_utils.c
+++ b/source/pwm/pwm_utils.c
@@ -1,22 +1,84 @@
-#include "hardware/pwm.h"
+/*  pwm_utils.c
+ *  This function currently supports up to three pins, PWM_PIN0, PWM_PIN1, PWM_PIN2
+ *  The PWM level can be set from 0 to 4095.
+ *  The PWM frequency is approximately 30.517 kHz
+*/
 
+
+// ******** includes *****************
+#include "hardware/pwm.h"
 #include "pwm_utils.h"
 
+// ********** global variables *********
+uint slice_num[3]; // PWM slice value for each pin (two slices are used)
+int pwm_level[3]; // PWM level for each pin
+
+// *********** functions ***********
+
+// pin_index is 0-2, and level is 0-4095
+void
+set_pwm_level(int pin_index, int level) {
+    uint chan = 0;
+    // The PWM module uses the concept of slices and channels.
+    // For the three PWM pins, two slices are used. The mapping is:
+    // PWM Pin index #:  0   1   2
+    // Slice #:          0   0   1
+    // Channel #:        0   1   0
+    if (pin_index == 1) {
+        chan = 1;
+    }
+    pwm_level[pin_index] = level;
+    pwm_set_chan_level(slice_num[pin_index], chan, level); // set PWM value
+}
+
 void initPwmUtils() {
-    // TODO pwm_init();
+    return; // nothing to do
 }
 
 uint32_t pwmPinCount() {
-    // TODO implement
-    return 0;
+    return(3); // The PWM pins are always enabled
 }
 
 void initPwmPins() {
-    // TODO implement
-    return;
+    int i;
+    // set the PWM pin functions
+    gpio_set_function(PWM_PIN0, GPIO_FUNC_PWM);
+    gpio_set_function(PWM_PIN1, GPIO_FUNC_PWM);
+    gpio_set_function(PWM_PIN2, GPIO_FUNC_PWM);
+    // store slice numbers. Each slice supports two pins (i.e. two channels)
+    // The pins are ordered such that the slice numbers are 0, 0, 1 for pin indexes 0, 1, 2.
+    slice_num[0] = pwm_gpio_to_slice_num(PWM_PIN0); // slice 0
+    slice_num[1] =  slice_num[0]; // same slice as slice_num[0]
+    slice_num[2] = pwm_gpio_to_slice_num(PWM_PIN2); // slice 1
+    // PWM clock
+    pwm_set_clkdiv(slice_num[0], CKDIV);
+    pwm_set_clkdiv(slice_num[2], CKDIV);
+    // the wrap value needs to be one less than the maximum value that will arrive via SCPI
+    // the SDK documentation on the other hand seems to suggest it should be the maximum value,
+    // but if you do that, then you can not reach 100.0% duty cycle.
+    // we want 0 to be 0% duty cycle, and PWM_MAX (4095) to be 100% duty cycle.
+    pwm_set_wrap(slice_num[0], PWM_MAX-1);
+    pwm_set_wrap(slice_num[2], PWM_MAX-1);
+    // default PWM levels set to zero
+    for (i=0; i<3; i++) {
+        set_pwm_level(i, 0);
+    }
+    // enable both PWM slices
+    pwm_set_enabled(slice_num[0], true);
+    pwm_set_enabled(slice_num[2], true);
 }
 
 void setPwmPinAt(uint32_t index, uint32_t value)  {
-    // TODO implement
+    // sanity check
+    if (value > PWM_MAX) {
+        value = PWM_MAX;
+    } else if (value < 0) {
+        value = 0;
+    }
+    set_pwm_level(index, value);
     return;
+}
+
+uint16_t getPwmPinAt(uint32_t index) {
+    return(pwm_level[index]);
 }

--- a/source/pwm/pwm_utils.h
+++ b/source/pwm/pwm_utils.h
@@ -1,9 +1,24 @@
 #ifndef _PWM_UTILS_H
 #define _PWM_UTILS_H
 
-void initPwmUtils();
-uint32_t pwmPinCount();
-void initPwmPins();
-void setPwmPinAt(uint32_t index, uint32_t value);
+/********** includes **********/
+#include "pico/stdlib.h"
+
+/******* defines *************/
+// frequency of PWM will be 125 MHz / (PWM_MAX * CKDIV)
+// i.e. about 30.5 kHz for PWM_MAX = 4095
+#define PWM_MAX 4095
+// set CKDIV to 1 for approx 30.5 kHz PWM frequency if PWM_MAX is 4095
+#define CKDIV 1
+#define PWM_PIN0 16
+#define PWM_PIN1 17
+#define PWM_PIN2 18
+
+/********* functions *********/
+void initPwmUtils(); // configures the PWM feature
+uint32_t pwmPinCount(); // returns the number of PWM pins (always 3)
+void initPwmPins(); // sets up the pin mode to PWM
+void setPwmPinAt(uint32_t index, uint32_t value); // sets the PWM pin index (0-3) PWM level to value (0-4095)
+uint16_t getPwmPinAt(uint32_t index); // returns the PWM level for the pin index (0-3)
 
 #endif // _PWM_UTILS_H

--- a/source/scpi/scpi-def.c
+++ b/source/scpi/scpi-def.c
@@ -139,7 +139,41 @@ static scpi_result_t SCPI_Analog16InputQ(scpi_t * context) {
     return SCPI_RES_OK;
 }
 
-// TODO pwm in commands
+// PWM
+static scpi_result_t SCPI_AnalogOutput(scpi_t * context) {
+    int32_t param1;
+    int32_t numbers[1];
+
+    // retrieve the output index
+    SCPI_CommandNumbers(context, numbers, 1, 0);
+    if (! ((numbers[0] > -1) && (numbers[0] < pwmPinCount()))) {
+        SCPI_ErrorPush(context, SCPI_ERROR_INVALID_SUFFIX);
+        return SCPI_RES_ERR;
+    }
+
+    /* read first parameter if present */
+    if (!SCPI_ParamInt32(context, &param1, TRUE)) {
+        return SCPI_RES_ERR;
+    }
+
+    setPwmPinAt(numbers[0], param1);
+
+    return SCPI_RES_OK;
+}
+
+static scpi_result_t SCPI_AnalogOutputQ(scpi_t * context) {
+    int32_t numbers[1];
+
+    // retrieve the pwm index
+    SCPI_CommandNumbers(context, numbers, 1, 0);
+    if (! ((numbers[0] > -1) && (numbers[0] < pwmPinCount()))) {
+        SCPI_ErrorPush(context, SCPI_ERROR_INVALID_SUFFIX);
+        return SCPI_RES_ERR;
+    }
+
+    SCPI_ResultUInt16(context, getPwmPinAt(numbers[0]));
+    return SCPI_RES_OK;
+}
 
 const scpi_command_t scpi_commands[] = {
     /* IEEE Mandated Commands (SCPI std V1999.0 4.1.1) */
@@ -166,10 +200,12 @@ const scpi_command_t scpi_commands[] = {
     {.pattern = "DIGItal:OUTPut#", .callback = SCPI_DigitalOutput,},
     {.pattern = "DIGItal:OUTPut#?", .callback = SCPI_DigitalOutputQ,},
     // TODO gpio in commands
-    // TODO adc commands
+    // adc commands
     {.pattern = "ANAlog:INPut#:RAW?", .callback = SCPI_AnalogInputQ,},
     {.pattern = "ANAlog:HIRES:INPut#:RAW?", .callback = SCPI_Analog16InputQ,},
-    // TODO pwm in commands
+    // pwm commands
+    {.pattern = "ANAlog:OUTPut#:RAW", .callback = SCPI_AnalogOutput,},
+    {.pattern = "ANAlog:OUTPut#:RAW?", .callback = SCPI_AnalogOutputQ,},
     SCPI_CMD_LIST_END
 };
 


### PR DESCRIPTION
Implemented the PWM feature, which is the ability for PWM to be generated on three output pins (GPIO pins 16, 17, 18) on the Pi Pico. 
The SCPI command syntax is:
ANA:OUTP#:RAW <0-4095>

The SCPI query syntax is:
ANA:OUTP#:RAW?

where # is a value [0..2]. The raw PWM range is 12-bit, i.e. 0-4095, corresponding to 0-100% duty cycle. 
The PWM frequency is approximately 30.5 kHz.
