### PR TITLE
only debug info if cmake config is Debug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,11 @@ project(pico_scpi_usbtmc_labtool C CXX ASM)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)
 
-#I've set this to allow breakpoints on any source line
-set(PICO_DEOPTIMIZED_DEBUG=1)
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    message(STATUS "  Diag: maximum debug info")
+    #I've set this to allow breakpoints on any source line
+    set(PICO_DEOPTIMIZED_DEBUG=1)
+endif ()
 
 pico_sdk_init()
 


### PR DESCRIPTION
changed CMake file to only apply this setting when the build configuration is "Debug":
`set(PICO_DEOPTIMIZED_DEBUG=1)`

closes #30 

