### PR TITLE
Issue 29 uniqueid usbtmc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ target_include_directories(pico_scpi_usbtmc_labtool PRIVATE
         $ENV{SCPI_LIB_PATH}/inc
 )
 
-target_link_libraries(pico_scpi_usbtmc_labtool PUBLIC pico_stdlib tinyusb_device tinyusb_board hardware_gpio hardware_adc hardware_pwm hardware_i2c)
+target_link_libraries(pico_scpi_usbtmc_labtool PUBLIC pico_stdlib tinyusb_device tinyusb_board hardware_gpio hardware_adc hardware_pwm hardware_i2c hardware_flash)
 pico_add_extra_outputs(pico_scpi_usbtmc_labtool)
 
 # usb output, uart output

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ target_include_directories(pico_scpi_usbtmc_labtool PRIVATE
         $ENV{SCPI_LIB_PATH}/inc
 )
 
-target_link_libraries(pico_scpi_usbtmc_labtool PUBLIC pico_stdlib tinyusb_device tinyusb_board hardware_gpio hardware_adc hardware_pwm hardware_i2c hardware_flash)
+target_link_libraries(pico_scpi_usbtmc_labtool PUBLIC pico_stdlib tinyusb_device tinyusb_board hardware_gpio hardware_adc hardware_pwm hardware_i2c pico_unique_id)
 pico_add_extra_outputs(pico_scpi_usbtmc_labtool)
 
 # usb output, uart output

--- a/source/usb/usb_descriptors.c
+++ b/source/usb/usb_descriptors.c
@@ -27,6 +27,8 @@
 #include "class/usbtmc/usbtmc.h"
 #include "class/usbtmc/usbtmc_device.h"
 
+#include "hardware/flash.h"
+
 /* A combination of interfaces must have a unique product id, since PC will save device driver after the first plug.
  * Same VID/PID with different interface e.g MSC (first), then CDC (later) will possibly cause system error on PC.
  *
@@ -194,7 +196,8 @@ char const* string_desc_arr [] =
   (const char[]) { 0x09, 0x04 }, // 0: is supported language is English (0x0409)
   "TinyUSB",                     // 1: Manufacturer
   "TinyUSB Device",              // 2: Product
-  "123456",                      // 3: Serials, should use chip ID
+  // jc: this fixed string will be replaced by Pico's 8 byte unique ID.
+  "88888888",                    // 3: Serial, placeholder for  chip ID
   "TinyUSB USBTMC",              // 4: USBTMC
 };
 
@@ -222,16 +225,28 @@ uint16_t const* tud_descriptor_string_cb(uint8_t index, uint16_t langid)
 
     const char* str = string_desc_arr[index];
 
+
     // Cap at max char
     chr_count = (uint8_t) strlen(str);
     if ( chr_count > 31 ) {
       chr_count = 31;
     }
 
-    // Convert ASCII string into UTF-16
-    for(uint8_t i=0; i<chr_count; i++)
-    {
-      _desc_str[1+i] = str[i];
+    if (index == 3) {
+      uint8_t unique_id[8];
+      flash_get_unique_id(unique_id);
+      // Convert ASCII string into UTF-16
+      for (uint8_t i = 0; i < chr_count; i++)
+      {
+        _desc_str[1 + i] = unique_id[i];
+      }
+
+    } else {
+      // Convert ASCII string into UTF-16
+      for (uint8_t i = 0; i < chr_count; i++)
+      {
+        _desc_str[1 + i] = str[i];
+      }
     }
   }
 

--- a/source/usb/usb_descriptors.c
+++ b/source/usb/usb_descriptors.c
@@ -27,7 +27,7 @@
 #include "class/usbtmc/usbtmc.h"
 #include "class/usbtmc/usbtmc_device.h"
 
-#include "hardware/flash.h"
+#include "pico/unique_id.h"
 
 /* A combination of interfaces must have a unique product id, since PC will save device driver after the first plug.
  * Same VID/PID with different interface e.g MSC (first), then CDC (later) will possibly cause system error on PC.
@@ -190,14 +190,16 @@ uint8_t const * tud_descriptor_configuration_cb(uint8_t index)
 // String Descriptors
 //--------------------------------------------------------------------+
 
+// buffer to hold flash ID
+char serial[2 * PICO_UNIQUE_BOARD_ID_SIZE_BYTES + 1];
+
 // array of pointer to string descriptors
 char const* string_desc_arr [] =
 {
   (const char[]) { 0x09, 0x04 }, // 0: is supported language is English (0x0409)
   "TinyUSB",                     // 1: Manufacturer
   "TinyUSB Device",              // 2: Product
-  // jc: this fixed string will be replaced by Pico's 8 byte unique ID.
-  "88888888",                    // 3: Serial, placeholder for  chip ID
+  serial,                        // 3: Serials, uses the flash ID
   "TinyUSB USBTMC",              // 4: USBTMC
 };
 
@@ -221,6 +223,8 @@ uint16_t const* tud_descriptor_string_cb(uint8_t index, uint16_t langid)
     // Note: the 0xEE index string is a Microsoft OS 1.0 Descriptors.
     // https://docs.microsoft.com/en-us/windows-hardware/drivers/usbcon/microsoft-defined-usb-descriptors
 
+    if (index == 3) pico_get_unique_board_id_string(serial, sizeof(serial));
+
     if ( !(index < sizeof(string_desc_arr)/sizeof(string_desc_arr[0])) ) return NULL;
 
     const char* str = string_desc_arr[index];
@@ -232,21 +236,10 @@ uint16_t const* tud_descriptor_string_cb(uint8_t index, uint16_t langid)
       chr_count = 31;
     }
 
-    if (index == 3) {
-      uint8_t unique_id[8];
-      flash_get_unique_id(unique_id);
-      // Convert ASCII string into UTF-16
-      for (uint8_t i = 0; i < chr_count; i++)
-      {
-        _desc_str[1 + i] = unique_id[i];
-      }
-
-    } else {
-      // Convert ASCII string into UTF-16
-      for (uint8_t i = 0; i < chr_count; i++)
-      {
-        _desc_str[1 + i] = str[i];
-      }
+    // Convert ASCII string into UTF-16
+    for (uint8_t i = 0; i < chr_count; i++)
+    {
+      _desc_str[1 + i] = str[i];
     }
   }
 


### PR DESCRIPTION
replaced the example usbtmc 123456 serial number with Pico unique id.
close #29 