### PR TITLE
Issue 35 refactor i2c initialisation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(pico_scpi_usbtmc_labtool
         ${CMAKE_CURRENT_SOURCE_DIR}/source/scpi/scpi-def.c
         ${CMAKE_CURRENT_SOURCE_DIR}/source/gpio/gpio_utils.c
         ${CMAKE_CURRENT_SOURCE_DIR}/source/adc/adc_utils.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/source/i2c/i2c_utils.c
         ${CMAKE_CURRENT_SOURCE_DIR}/source/adc16/adc16_utils.c
         ${CMAKE_CURRENT_SOURCE_DIR}/source/pwm/pwm_utils.c
         $ENV{SCPI_LIB_PATH}/src/parser.c
@@ -48,6 +49,7 @@ target_include_directories(pico_scpi_usbtmc_labtool PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/source/scpi
         ${CMAKE_CURRENT_LIST_DIR}/source/gpio
         ${CMAKE_CURRENT_LIST_DIR}/source/adc
+        ${CMAKE_CURRENT_LIST_DIR}/source/i2c
         ${CMAKE_CURRENT_LIST_DIR}/source/adc16
         ${CMAKE_CURRENT_LIST_DIR}/source/pwm
         $ENV{SCPI_LIB_PATH}/inc

--- a/source/adc16/adc16_utils.c
+++ b/source/adc16/adc16_utils.c
@@ -23,15 +23,6 @@ uint8_t adc16Installed = 0;
 uint32_t adc16Channel = 0;
 uint8_t confreg[2]; // config register
 
-/************** functions *****************/
-// initialize the I2C bus
-void initAdc16I2C(void) {
-    gpio_set_function(PICO_DEFAULT_I2C_SDA_PIN, GPIO_FUNC_I2C);
-    gpio_set_function(PICO_DEFAULT_I2C_SCL_PIN, GPIO_FUNC_I2C);
-    gpio_pull_up(PICO_DEFAULT_I2C_SDA_PIN); // weak pull-ups but enable them anyway
-    gpio_pull_up(PICO_DEFAULT_I2C_SCL_PIN);
-}
-
 // initialize the ADS1115 registers
 void initAdc16Reg(void) {
     uint8_t buf[3];

--- a/source/adc16/adc16_utils.c
+++ b/source/adc16/adc16_utils.c
@@ -26,7 +26,6 @@ uint8_t confreg[2]; // config register
 /************** functions *****************/
 // initialize the I2C bus
 void initAdc16I2C(void) {
-    i2c_init(i2c_default, 10000); // I2C0 on GPIO 4[SDA],5[SCL]
     gpio_set_function(PICO_DEFAULT_I2C_SDA_PIN, GPIO_FUNC_I2C);
     gpio_set_function(PICO_DEFAULT_I2C_SCL_PIN, GPIO_FUNC_I2C);
     gpio_pull_up(PICO_DEFAULT_I2C_SDA_PIN); // weak pull-ups but enable them anyway

--- a/source/adc16/adc16_utils.h
+++ b/source/adc16/adc16_utils.h
@@ -21,7 +21,6 @@
 #define ADS1115_DIFF_2_3 0x11
 
 /******* functions *********/
-void initAdc16I2C(void);
 void initAdc16Reg(void);
 uint32_t adc16PinCount();
 uint16_t getAdc16PinAt(uint32_t index);

--- a/source/i2c/i2c_utils.c
+++ b/source/i2c/i2c_utils.c
@@ -1,8 +1,14 @@
-#include "hardware/i2c.h"
-
 #include "i2c_utils.h"
 
+#include "hardware/gpio.h"
+#include "hardware/i2c.h"
+
+// initialize the I2C bus
 void initI2CUtils() {
     i2c_init(i2c_default, 10000); // I2C0 on GPIO 4[SDA],5[SCL]
+    gpio_set_function(PICO_DEFAULT_I2C_SDA_PIN, GPIO_FUNC_I2C);
+    gpio_set_function(PICO_DEFAULT_I2C_SCL_PIN, GPIO_FUNC_I2C);
+    gpio_pull_up(PICO_DEFAULT_I2C_SDA_PIN); // weak pull-ups but enable them anyway
+    gpio_pull_up(PICO_DEFAULT_I2C_SCL_PIN);
     return;
 }

--- a/source/i2c/i2c_utils.c
+++ b/source/i2c/i2c_utils.c
@@ -1,0 +1,8 @@
+#include "hardware/i2c.h"
+
+#include "i2c_utils.h"
+
+void initI2CUtils() {
+    i2c_init(i2c_default, 10000); // I2C0 on GPIO 4[SDA],5[SCL]
+    return;
+}

--- a/source/i2c/i2c_utils.h
+++ b/source/i2c/i2c_utils.h
@@ -1,0 +1,8 @@
+#ifndef _I2C_UTILS_H
+#define _I2C_UTILS_H
+
+void initI2CUtils();
+
+
+
+#endif // _I2C_UTILS_H

--- a/source/scpi/scpi-def.c
+++ b/source/scpi/scpi-def.c
@@ -52,6 +52,7 @@
 
 #include "gpio_utils.h"
 #include "adc_utils.h"
+#include "i2c_utils.h"
 #include "adc16_utils.h"
 #include "pwm_utils.h"
 
@@ -264,6 +265,7 @@ scpi_result_t SCPI_Reset(scpi_t * context) {
 void initInstrument() {
     initGpioUtils();
     initOutPins();
+    initI2CUtils();
     // TODO input pins
     initAdcUtils();
     initAdcPins();

--- a/source/scpi/scpi-def.c
+++ b/source/scpi/scpi-def.c
@@ -269,7 +269,6 @@ void initInstrument() {
     // TODO input pins
     initAdcUtils();
     initAdcPins();
-    initAdc16I2C();
     initAdc16Reg();
     initPwmUtils();
     initPwmPins();


### PR DESCRIPTION
refactor: moved initAdc16I2C() into a separate module i2C (i2c_utlis.h and .c)
for case where we want 2 i2c ICs, or a different one.
closes #35 