### PR TITLE
Issue 41 scpi device status register and gpio in

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,9 @@ target_include_directories(pico_scpi_usbtmc_labtool PRIVATE
 target_link_libraries(pico_scpi_usbtmc_labtool PUBLIC pico_stdlib tinyusb_device tinyusb_board hardware_gpio hardware_adc hardware_pwm hardware_i2c)
 pico_add_extra_outputs(pico_scpi_usbtmc_labtool)
 
+# enable use of scpi_user_config.h, to support custom device specific registers 
+target_compile_definitions(pico_scpi_usbtmc_labtool PRIVATE SCPI_USER_CONFIG=1)
+
 # usb output, uart output
  pico_enable_stdio_usb(pico_scpi_usbtmc_labtool 0)
  pico_enable_stdio_uart(pico_scpi_usbtmc_labtool 0)

--- a/source/gpio/gpio_utils.c
+++ b/source/gpio/gpio_utils.c
@@ -36,7 +36,6 @@ void initInPins() {
     for (uint32_t i = 0; i < inPinCount(); i++) {
         gpio_init(inPins[i]);
         gpio_set_dir(inPins[i], false);
-        gpio_put(inPins[i], 0);
     }
 }
 

--- a/source/main.c
+++ b/source/main.c
@@ -66,6 +66,7 @@ int main(void)
   {
     tud_task(); // tinyusb device task
     led_blinking_task();
+    fillRegs();
     usbtmc_app_task_iter();
   }
 

--- a/source/main.c
+++ b/source/main.c
@@ -66,7 +66,7 @@ int main(void)
   {
     tud_task(); // tinyusb device task
     led_blinking_task();
-    fillRegs();
+    maintainInstrumentRegs();
     usbtmc_app_task_iter();
   }
 

--- a/source/scpi/scpi-def.c
+++ b/source/scpi/scpi-def.c
@@ -188,6 +188,108 @@ static scpi_result_t SCPI_AnalogOutputQ(scpi_t * context) {
     return SCPI_RES_OK;
 }
 
+/**
+ * STATus:OPERation:DIGItal:INPut:EVENt?
+ * @param context
+ * @return
+ */
+scpi_result_t SCPI_StatusOperationDigitalInputEventQ(scpi_t * context) {
+    /* return value */
+    SCPI_ResultInt32(context, SCPI_RegGet(context, USER_REG_DIGINEVENT));
+
+    /* clear register */
+    SCPI_RegSet(context, USER_REG_DIGINEVENT, 0);
+
+    return SCPI_RES_OK;
+}
+
+/**
+ * STATus:OPERation:DIGItal:INPut:CONDition?
+ * @param context
+ * @return
+ */
+scpi_result_t SCPI_StatusOperationDigitalInputConditionQ(scpi_t * context) {
+    /* return value */
+    SCPI_ResultInt32(context, SCPI_RegGet(context, USER_REG_DIGINEVENTC));
+
+    return SCPI_RES_OK;
+}
+
+/**
+ * STATus:OPERation:DIGItal:INPut:ENABle
+ * @param context
+ * @return
+ */
+scpi_result_t SCPI_StatusOperationDigitalInputEnable(scpi_t * context) {
+    int32_t new_OPERE;
+    if (SCPI_ParamInt32(context, &new_OPERE, TRUE)) {
+        SCPI_RegSet(context, USER_REG_DIGINEVENTE, (scpi_reg_val_t) new_OPERE);
+    }
+    return SCPI_RES_OK;
+}
+
+/**
+ * STATus:OPERation:DIGItal:INPut:ENABle?
+ * @param context
+ * @return
+ */
+ scpi_result_t SCPI_StatusOperationDigitalInputEnableQ(scpi_t * context) {
+    /* return value */
+    SCPI_ResultInt32(context, SCPI_RegGet(context, USER_REG_DIGINEVENTE));
+
+    return SCPI_RES_OK;
+}
+
+/**
+ * STATus:OPERation:DIGItal:INPut:PTRansition
+ * @param context
+ * @return
+ */
+scpi_result_t SCPI_StatusOperationDigitalInputPTransition(scpi_t * context) {
+    int32_t new_OPERE;
+    if (SCPI_ParamInt32(context, &new_OPERE, TRUE)) {
+        SCPI_RegSet(context, USER_REG_DIGINEVENTP, (scpi_reg_val_t) new_OPERE);
+    }
+    return SCPI_RES_OK;
+}
+
+/**
+ * STATus:OPERation:DIGItal:INPut:PTRansition?
+ * @param context
+ * @return
+ */
+ scpi_result_t SCPI_StatusOperationDigitalInputPTransitionQ(scpi_t * context) {
+    /* return value */
+    SCPI_ResultInt32(context, SCPI_RegGet(context, USER_REG_DIGINEVENTP));
+
+    return SCPI_RES_OK;
+}
+
+/**
+ * STATus:OPERation:DIGItal:INPut:NTRansition
+ * @param context
+ * @return
+ */
+scpi_result_t SCPI_StatusOperationDigitalInputNTransition(scpi_t * context) {
+    int32_t new_OPERE;
+    if (SCPI_ParamInt32(context, &new_OPERE, TRUE)) {
+        SCPI_RegSet(context, USER_REG_DIGINEVENTN, (scpi_reg_val_t) new_OPERE);
+    }
+    return SCPI_RES_OK;
+}
+
+/**
+ * STATus:OPERation:DIGItal:INPut:NTRansition?
+ * @param context
+ * @return
+ */
+ scpi_result_t SCPI_StatusOperationDigitalInputNTransitionQ(scpi_t * context) {
+    /* return value */
+    SCPI_ResultInt32(context, SCPI_RegGet(context, USER_REG_DIGINEVENTN));
+
+    return SCPI_RES_OK;
+}
+
 const scpi_command_t scpi_commands[] = {
     /* IEEE Mandated Commands (SCPI std V1999.0 4.1.1) */
     { .pattern = "*CLS", .callback = SCPI_CoreCls,},
@@ -232,6 +334,17 @@ const scpi_command_t scpi_commands[] = {
     // pwm commands
     {.pattern = "ANAlog:OUTPut#:RAW", .callback = SCPI_AnalogOutput,},
     {.pattern = "ANAlog:OUTPut#:RAW?", .callback = SCPI_AnalogOutputQ,},
+
+    // instrument specific registers commands
+    {.pattern = "STATus:OPERation:DIGItal:INPut:EVENt?", .callback = SCPI_StatusOperationDigitalInputEventQ,},
+    {.pattern = "STATus:OPERation:DIGItal:INPut:CONDition?", .callback = SCPI_StatusOperationDigitalInputConditionQ,},
+    {.pattern = "STATus:OPERation:DIGItal:INPut:ENABle", .callback = SCPI_StatusOperationDigitalInputEnable,},
+    {.pattern = "STATus:OPERation:DIGItal:INPut:ENABle?", .callback = SCPI_StatusOperationDigitalInputEnableQ,},
+    {.pattern = "STATus:OPERation:DIGItal:INPut:PTRansition", .callback = SCPI_StatusOperationDigitalInputPTransition,},
+    {.pattern = "STATus:OPERation:DIGItal:INPut:PTRansition?", .callback = SCPI_StatusOperationDigitalInputPTransitionQ,},
+    {.pattern = "STATus:OPERation:DIGItal:INPut:NTRansition", .callback = SCPI_StatusOperationDigitalInputNTransition,},
+    {.pattern = "STATus:OPERation:DIGItal:INPut:NTRansition?", .callback = SCPI_StatusOperationDigitalInputNTransitionQ,},
+
     SCPI_CMD_LIST_END
 };
 
@@ -299,6 +412,18 @@ void initInstrument() {
     initPwmPins();
 }
 
+/**
+ * current implementation does not use interrupts to set the digital in control register
+*/
+void maintainDigiInReg() {
+    scpi_reg_val_t digi_in = 0U;
+    for (uint32_t i = 0; i < inPinCount(); i++) {
+      int j = isInPinAt(i) << i;      
+      digi_in |= j ;
+    }
+    SCPI_RegSet(&scpi_context, USER_REG_DIGINEVENTC, digi_in);
+}
+
 void maintainInstrumentRegs() {
-  // TODO get digital pin in status and write to device dependent register
+  maintainDigiInReg();
 }

--- a/source/scpi/scpi-def.c
+++ b/source/scpi/scpi-def.c
@@ -162,6 +162,19 @@ const scpi_command_t scpi_commands[] = {
     {.pattern = "SYSTem:ERRor:COUNt?", .callback = SCPI_SystemErrorCountQ,},
     {.pattern = "SYSTem:VERSion?", .callback = SCPI_SystemVersionQ,},
 
+
+    {.pattern = "STATus:OPERation:EVENt?", .callback = SCPI_StatusOperationEventQ,},
+    {.pattern = "STATus:OPERation:CONDition?", .callback = SCPI_StatusOperationConditionQ,},
+    {.pattern = "STATus:OPERation:ENABle", .callback = SCPI_StatusOperationEnable,},
+    {.pattern = "STATus:OPERation:ENABle?", .callback = SCPI_StatusOperationEnableQ,},
+
+    {.pattern = "STATus:QUEStionable[:EVENt]?", .callback = SCPI_StatusQuestionableEventQ,},
+    /* {.pattern = "STATus:QUEStionable:CONDition?", .callback = scpi_stub_callback,}, */
+    {.pattern = "STATus:QUEStionable:ENABle", .callback = SCPI_StatusQuestionableEnable,},
+    {.pattern = "STATus:QUEStionable:ENABle?", .callback = SCPI_StatusQuestionableEnableQ,},
+
+    {.pattern = "STATus:PRESet", .callback = SCPI_StatusPreset,},
+
     /* custom commands for the switch */
     {.pattern = "DIGItal:OUTPut#", .callback = SCPI_DigitalOutput,},
     {.pattern = "DIGItal:OUTPut#?", .callback = SCPI_DigitalOutputQ,},

--- a/source/scpi/scpi-def.c
+++ b/source/scpi/scpi-def.c
@@ -298,3 +298,7 @@ void initInstrument() {
     initPwmUtils();
     initPwmPins();
 }
+
+void fillRegs() {
+  
+}

--- a/source/scpi/scpi-def.c
+++ b/source/scpi/scpi-def.c
@@ -299,6 +299,6 @@ void initInstrument() {
     initPwmPins();
 }
 
-void fillRegs() {
-  
+void maintainInstrumentRegs() {
+  // TODO get digital pin in status and write to device dependent register
 }

--- a/source/scpi/scpi-def.h
+++ b/source/scpi/scpi-def.h
@@ -31,7 +31,7 @@ scpi_result_t SCPI_Reset(scpi_t * context);
 scpi_result_t SCPI_Flush(scpi_t * context);
 
 
-void fillRegs();
+void maintainInstrumentRegs();
 
 #endif /* __SCPI_DEF_H_ */
 

--- a/source/scpi/scpi-def.h
+++ b/source/scpi/scpi-def.h
@@ -31,7 +31,7 @@ scpi_result_t SCPI_Reset(scpi_t * context);
 scpi_result_t SCPI_Flush(scpi_t * context);
 
 
-scpi_result_t SCPI_SystemCommTcpipControlQ(scpi_t * context);
+void fillRegs();
 
 #endif /* __SCPI_DEF_H_ */
 

--- a/source/scpi/scpi_user_config.h
+++ b/source/scpi/scpi_user_config.h
@@ -1,0 +1,5 @@
+#ifndef _SCPI_USER_CONFIG_H
+#define _SCPI_USER_CONFIG_H
+
+
+#endif // _SCPI_USER_CONFIG_H

--- a/source/scpi/scpi_user_config.h
+++ b/source/scpi/scpi_user_config.h
@@ -1,12 +1,28 @@
 #ifndef _SCPI_USER_CONFIG_H
 #define _SCPI_USER_CONFIG_H
 
-#define USE_CUSTOM_REGISTERS 1
-#define USER_REGISTERS
-#define USER_REGISTER_GROUPS
-#define USER_REGISTER_DETAILS
-#define USER_REGISTER_GROUP_DETAILS
-// TODO define custom status registers
 
+// define instrument specific registers
+#define USE_CUSTOM_REGISTERS 1
+#define USER_REGISTERS \
+        USER_REG_DIGINEVENT, /* Digital In event status Register */ \
+        USER_REG_DIGINEVENTE, /* Digital In event status enable Register */
+#define USER_REGISTER_GROUPS \
+        USER_REG_GROUP_DIGINEVENT,
+
+#define USER_REGISTER_DETAILS \
+    { SCPI_REG_CLASS_EVEN, USER_REG_GROUP_DIGINEVENT }, \
+    { SCPI_REG_CLASS_ENAB, USER_REG_GROUP_DIGINEVENT },
+
+#define USER_REGISTER_GROUP_DETAILS \
+{ \
+        USER_REG_DIGINEVENT, \
+        USER_REG_DIGINEVENTE, \
+        SCPI_REG_NONE, \
+        SCPI_REG_NONE, \
+        SCPI_REG_NONE, \
+        SCPI_REG_STB, \
+        STB_QES  /* TODO what value should I put here? */ \
+    }, /* USER_REG_GROUP_DIGINEVENT */
 
 #endif // _SCPI_USER_CONFIG_H

--- a/source/scpi/scpi_user_config.h
+++ b/source/scpi/scpi_user_config.h
@@ -26,10 +26,10 @@
         USER_REG_DIGINEVENT, \
         USER_REG_DIGINEVENTE, \
         USER_REG_DIGINEVENTC, \
-		USER_REG_DIGINEVENTP, \
-		USER_REG_DIGINEVENTN, \
-		SCPI_REG_OPER, \
-		1  /* TODO this defines to what bit of the parent we trickle through */ \
+	USER_REG_DIGINEVENTP, \
+	USER_REG_DIGINEVENTN, \
+	SCPI_REG_OPER, \
+	1  /* this defines to what bit of the parent we trickle through */ \
     }, /* USER_REG_GROUP_DIGINEVENT */
 
 #endif // _SCPI_USER_CONFIG_H

--- a/source/scpi/scpi_user_config.h
+++ b/source/scpi/scpi_user_config.h
@@ -1,5 +1,12 @@
 #ifndef _SCPI_USER_CONFIG_H
 #define _SCPI_USER_CONFIG_H
 
+#define USE_CUSTOM_REGISTERS 1
+#define USER_REGISTERS
+#define USER_REGISTER_GROUPS
+#define USER_REGISTER_DETAILS
+#define USER_REGISTER_GROUP_DETAILS
+// TODO define custom status registers
+
 
 #endif // _SCPI_USER_CONFIG_H

--- a/source/scpi/scpi_user_config.h
+++ b/source/scpi/scpi_user_config.h
@@ -4,9 +4,11 @@
 
 // define instrument specific registers
 #define USE_CUSTOM_REGISTERS 1
+
 #define USER_REGISTERS \
         USER_REG_DIGINEVENT, /* Digital In event status Register */ \
         USER_REG_DIGINEVENTE, /* Digital In event status enable Register */
+
 #define USER_REGISTER_GROUPS \
         USER_REG_GROUP_DIGINEVENT,
 
@@ -22,7 +24,7 @@
         SCPI_REG_NONE, \
         SCPI_REG_NONE, \
         SCPI_REG_STB, \
-        STB_QES  /* TODO what value should I put here? */ \
+        STB_OPS  /* TODO what value should I put here? */ \
     }, /* USER_REG_GROUP_DIGINEVENT */
 
 #endif // _SCPI_USER_CONFIG_H

--- a/source/scpi/scpi_user_config.h
+++ b/source/scpi/scpi_user_config.h
@@ -1,30 +1,35 @@
 #ifndef _SCPI_USER_CONFIG_H
 #define _SCPI_USER_CONFIG_H
 
-
 // define instrument specific registers
 #define USE_CUSTOM_REGISTERS 1
 
 #define USER_REGISTERS \
         USER_REG_DIGINEVENT, /* Digital In event status Register */ \
-        USER_REG_DIGINEVENTE, /* Digital In event status enable Register */
+        USER_REG_DIGINEVENTE, /* Digital In event status enable Register */ \
+        USER_REG_DIGINEVENTC, /* Digital In event status condition Register */ \
+        USER_REG_DIGINEVENTP, /* Digital In event status positive filter Register */ \
+        USER_REG_DIGINEVENTN, /* Digital In event status negative register Register */
 
 #define USER_REGISTER_GROUPS \
         USER_REG_GROUP_DIGINEVENT,
 
 #define USER_REGISTER_DETAILS \
     { SCPI_REG_CLASS_EVEN, USER_REG_GROUP_DIGINEVENT }, \
-    { SCPI_REG_CLASS_ENAB, USER_REG_GROUP_DIGINEVENT },
+    { SCPI_REG_CLASS_ENAB, USER_REG_GROUP_DIGINEVENT }, \
+    { SCPI_REG_CLASS_COND, USER_REG_GROUP_DIGINEVENT }, \
+    { SCPI_REG_CLASS_PTR, USER_REG_GROUP_DIGINEVENT }, \
+    { SCPI_REG_CLASS_NTR, USER_REG_GROUP_DIGINEVENT },
 
 #define USER_REGISTER_GROUP_DETAILS \
 { \
         USER_REG_DIGINEVENT, \
         USER_REG_DIGINEVENTE, \
-        SCPI_REG_NONE, \
-        SCPI_REG_NONE, \
-        SCPI_REG_NONE, \
-        SCPI_REG_STB, \
-        STB_ESR  /* TODO what value should I put here? */ \
+        USER_REG_DIGINEVENTC, \
+		USER_REG_DIGINEVENTP, \
+		USER_REG_DIGINEVENTN, \
+		SCPI_REG_OPER, \
+		1  /* TODO this defines to what bit of the parent we trickle through */ \
     }, /* USER_REG_GROUP_DIGINEVENT */
 
 #endif // _SCPI_USER_CONFIG_H

--- a/source/scpi/scpi_user_config.h
+++ b/source/scpi/scpi_user_config.h
@@ -24,7 +24,7 @@
         SCPI_REG_NONE, \
         SCPI_REG_NONE, \
         SCPI_REG_STB, \
-        STB_OPS  /* TODO what value should I put here? */ \
+        STB_ESR  /* TODO what value should I put here? */ \
     }, /* USER_REG_GROUP_DIGINEVENT */
 
 #endif // _SCPI_USER_CONFIG_H


### PR DESCRIPTION
implemented registers for digital in 
```
USER_REG_DIGINEVENT, /* Digital In event status Register */ \
USER_REG_DIGINEVENTE, /* Digital In event status enable Register */ \
USER_REG_DIGINEVENTC, /* Digital In event status condition Register */ \
USER_REG_DIGINEVENTP, /* Digital In event status positive filter Register */ \
USER_REG_DIGINEVENTN, /* Digital In event status negative register Register */

```
SCPI commands:
```
STATus:OPERation:DIGItal:INPut:EVENt?
STATus:OPERation:DIGItal:INPut:CONDition?
STATus:OPERation:DIGItal:INPut:ENABle
STATus:OPERation:DIGItal:INPut:ENABle?
STATus:OPERation:DIGItal:INPut:PTRansition
STATus:OPERation:DIGItal:INPut:PTRansition?
STATus:OPERation:DIGItal:INPut:NTRansition
STATus:OPERation:DIGItal:INPut:NTRansition?

```
Utility function to maintain custom registers
`maintainInstrumentRegs()`

Function to maintain the digital in registers (at this moment, called from the main loop
`maintainDigiInReg()`

SCPI standard registers integration:
When configured (with SCPI commands), can trickle down the hierarchy to the OPERATIONS register, and to the OPERATIONS bit in the STATUS BYTE