### PR TITLE
delegated handling of SRQ to USBTMC code

### DIFF
--- a/source/scpi/scpi-def.c
+++ b/source/scpi/scpi-def.c
@@ -351,7 +351,7 @@ const scpi_command_t scpi_commands[] = {
 scpi_interface_t scpi_interface = {
     .error = NULL,            // haven't implemented an error logger
     .write = SCPI_Write,
-    .control = NULL,        // haven't implemented communication channel control
+    .control = SCPI_Control,
     .flush = NULL,            // don't need flush for SCI / USB
     .reset = SCPI_Reset,
 };
@@ -398,6 +398,17 @@ scpi_result_t SCPI_Reset(scpi_t * context) {
     (void) context;
     initInstrument();
     return SCPI_RES_OK;   
+}
+
+scpi_result_t SCPI_Control(scpi_t* context, scpi_ctrl_name_t ctrl, scpi_reg_val_t val)
+{
+    (void)context;
+    (void) val;
+
+    if (SCPI_CTRL_SRQ == ctrl) {
+        setControlReply();
+    }
+    return SCPI_RES_OK;
 }
 
 uint8_t getSTB() {

--- a/source/usb/usbtmc_app.c
+++ b/source/usb/usbtmc_app.c
@@ -328,7 +328,15 @@ void setReply (const char *data, size_t len) {
   // attach replies to the buffer until the SCPI engine is finished.
   // no one should run away with the data, because only one core has focus 
   // on scpi engine and USB state machine 
-  // TODO verify
   memcpy(reply + (reply_len * sizeof reply[0]), data, len);
   reply_len += len;
 }
+
+void setControlReply () {
+  // TODO find how to support service request calls 
+/*   reply[0] = 0x81;
+  reply[1] = getSTB();
+  reply_len = 2;
+  // queryState = 1; nah */
+}
+

--- a/source/usb/usbtmc_app.h
+++ b/source/usb/usbtmc_app.h
@@ -5,5 +5,6 @@
 void usbtmc_app_task_iter(void);
 
 void setReply (const char *data, size_t len);
+void setControlReply ();
 
 #endif


### PR DESCRIPTION
The SCPI lib does not know how SRQ handling in USBTMC has to happen.  
I don't know either.

To ease later development, and to take this burden away from the SCPI lib, I made the SCPI lib call a placeholder function in the USBTMC part of the code.

No functional change, but clarification of responsibillities.

the new setControlReply() function doesn't do anything,  
but I put in the comments my trial code, based on reading specs and opinions.