### PR TITLE
Issue 49 let usbtmc trigger call same function as scpi  trg

### DIFF
--- a/source/scpi/scpi-def.c
+++ b/source/scpi/scpi-def.c
@@ -290,6 +290,25 @@ scpi_result_t SCPI_StatusOperationDigitalInputNTransition(scpi_t * context) {
     return SCPI_RES_OK;
 }
 
+void triggerHandler() {
+    // this function is the handler for SCPI and usbtmc trigger requests.
+    // current firmware ignores triggers
+    // if there is a use for it, move this to the dedicated module
+    return;
+}
+
+/**
+ * *TRG - This command asserts trigger. 
+ *        https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/visa-assert-trigger.html
+ * @param context
+ * @return 
+ */
+scpi_result_t SCPI_VisaTrg(scpi_t * context) {
+    (void) context;
+    triggerHandler();
+    return SCPI_RES_OK;
+}
+
 const scpi_command_t scpi_commands[] = {
     /* IEEE Mandated Commands (SCPI std V1999.0 4.1.1) */
     { .pattern = "*CLS", .callback = SCPI_CoreCls,},
@@ -344,6 +363,11 @@ const scpi_command_t scpi_commands[] = {
     {.pattern = "STATus:OPERation:DIGItal:INPut:PTRansition?", .callback = SCPI_StatusOperationDigitalInputPTransitionQ,},
     {.pattern = "STATus:OPERation:DIGItal:INPut:NTRansition", .callback = SCPI_StatusOperationDigitalInputNTransition,},
     {.pattern = "STATus:OPERation:DIGItal:INPut:NTRansition?", .callback = SCPI_StatusOperationDigitalInputNTransitionQ,},
+
+    // VISA commands
+    // support VISA ASSERT TRIGGER 
+    // https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/visa-assert-trigger.html
+    { .pattern = "*TRG", .callback = SCPI_VisaTrg,},
 
     SCPI_CMD_LIST_END
 };
@@ -417,6 +441,10 @@ uint8_t getSTB() {
 
 void setSTB(uint8_t stb) {
     SCPI_RegSet(&scpi_context, SCPI_REG_STB, (scpi_reg_val_t) stb);    
+}
+
+void doTrigger() {
+    triggerHandler();
 }
 
 void initInstrument() {

--- a/source/scpi/scpi-def.c
+++ b/source/scpi/scpi-def.c
@@ -300,13 +300,14 @@ void triggerHandler() {
 /**
  * *TRG - This command asserts trigger. 
  *        https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/visa-assert-trigger.html
+ *        throw SCPI error, because not implemented
  * @param context
  * @return 
  */
 scpi_result_t SCPI_VisaTrg(scpi_t * context) {
-    (void) context;
     triggerHandler();
-    return SCPI_RES_OK;
+    SCPI_ErrorPush(context, SCPI_ERROR_UNDEFINED_HEADER); // TODO: remove when trigger implemented
+    return SCPI_RES_ERR; // TODO: return OK when trigger implemented
 }
 
 const scpi_command_t scpi_commands[] = {

--- a/source/scpi/scpi-def.h
+++ b/source/scpi/scpi-def.h
@@ -33,6 +33,7 @@ scpi_result_t SCPI_Flush(scpi_t * context);
 // helper functions to simplyfy integration of TinyUSB tmcusb and the scpi-lib
 uint8_t getSTB();
 void setSTB(uint8_t);
+void doTrigger();
 
 
 void maintainInstrumentRegs();

--- a/source/usb/usbtmc_app.c
+++ b/source/usb/usbtmc_app.c
@@ -119,6 +119,7 @@ bool tud_usbtmc_msg_trigger_cb(usbtmc_msg_generic_t* msg) {
   // TODO: locks usb communication after trigger, 
   // until a usbtmc clear command is sent
   // not related with adding the doTrigger() call above...
+  // it also fails and time outs in the TinyUSB example program
   // is this related with setting the SCPI-LIB STB below?
   // Let trigger set the SRQ
   uint8_t status = getSTB();

--- a/source/usb/usbtmc_app.c
+++ b/source/usb/usbtmc_app.c
@@ -114,10 +114,17 @@ tud_usbtmc_get_capabilities_cb()
 
 bool tud_usbtmc_msg_trigger_cb(usbtmc_msg_generic_t* msg) {
   (void)msg;
+  doTrigger();
+  // TODO: check if this is TinyUSB example code, or needed
+  // TODO: locks usb communication after trigger, 
+  // until a usbtmc clear command is sent
+  // not related with adding the doTrigger() call above...
+  // is this related with setting the SCPI-LIB STB below?
   // Let trigger set the SRQ
   uint8_t status = getSTB();
   status |= IEEE4882_STB_SRQ;
   setSTB(status);
+
   return true;
 }
 


### PR DESCRIPTION
make USB and SCPI trigger commands call same code.
At this time, that code does nothing. 
Also, usbtmc part is not stable in their example code.
At this moment, functionality to be avoided.