### PR TITLE
use lablib with embedded scpi-lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,14 +48,6 @@ add_executable(pico_scpi_usbtmc_labtool
         ${CMAKE_CURRENT_SOURCE_DIR}/source/i2c/i2c_utils.c
         ${CMAKE_CURRENT_SOURCE_DIR}/source/adc16/adc16_utils.c
         ${CMAKE_CURRENT_SOURCE_DIR}/source/pwm/pwm_utils.c
-        $ENV{SCPI_LIB_PATH}/src/parser.c
-        $ENV{SCPI_LIB_PATH}/src/lexer.c
-        $ENV{SCPI_LIB_PATH}/src/error.c
-        $ENV{SCPI_LIB_PATH}/src/ieee488.c
-        $ENV{SCPI_LIB_PATH}/src/minimal.c
-        $ENV{SCPI_LIB_PATH}/src/utils.c
-        $ENV{SCPI_LIB_PATH}/src/units.c
-        $ENV{SCPI_LIB_PATH}/src/fifo.c
         source/adc16/adc16_utils.c source/adc16/adc16_utils.h)
 
 target_include_directories(pico_scpi_usbtmc_labtool PRIVATE
@@ -67,7 +59,6 @@ target_include_directories(pico_scpi_usbtmc_labtool PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/source/i2c
         ${CMAKE_CURRENT_LIST_DIR}/source/adc16
         ${CMAKE_CURRENT_LIST_DIR}/source/pwm
-        $ENV{SCPI_LIB_PATH}/inc
 )
 
 target_link_libraries(pico_scpi_usbtmc_labtool PUBLIC pico_stdlib 

--- a/README.md
+++ b/README.md
@@ -5,17 +5,15 @@ LabVIEW compatible instrument on a Raspberry Pico
 Prerequisites:  
 Toolchain (and IDE) that can build Pico projects with CMake  
 Pico C SDK 1.5  
-Jan Breuer [SCPI library](https://github.com/j123b567/scpi-parser)  
 
-Clone the repository with its subrepositories, to get the application and the Pico SCPI USBTMC_LabLib (PSL) sources:  
+Clone the repository with its subrepositories, to get the application, the Pico SCPI USBTMC_LabLib (PSL) sources, and the Jan Breuer SCPI library:  
 git clone https://github.com/jancumps/pico_scpi_usbtmc_labtool.git  --recurse-submodules  
 _If you download the archive from github instead, then also download [Pico SCPI USBTMC_LabLib (PSL)](https://github.com/jancumps/pico_scpi_usbtmc_lablib). Extract its contents into the ./pico_scpi_isbtmc_lablib folder._  
 
 
-Add these two variables to your environment:  
+Add this variable to your environment:  
 
     PICO_SDK_PATH (e.g.: C:/Users/jancu/Documents/Pico/pico-sdk)  
-    SCPI_LIB_PATH (e.g.: C:/Users/jancu/Documents/elektronica/scpi/scpi-parser/libscpi)
 
 If you use VSCode, you can define them via Preferences -> User -> Extensions -> CMake Tools -> CMake: Configure Environment.  
 


### PR DESCRIPTION
I added the the Jan Breuer [SCPI library](https://github.com/j123b567/scpi-parser) as a submodule of the PSL.

In this PST project, I bumped the PSLsubmodule pointer to that new version with the submodule.  
I updated the build file, and removed any dependency on scpi-lib (they are now handled in PSL).  
It's no longer needed to clone the SCPI-LIB. Also no longer needed to set the environment variable.  
I updated the readme.  

