### PR TITLE
unique id in scpi  idn, support custom scpi reply terminator

### DIFF
--- a/source/scpi/scpi-def.h
+++ b/source/scpi/scpi-def.h
@@ -9,7 +9,7 @@
 // model
 #define SCPI_IDN2 "LABTOOL"
 // serial number
-#define SCPI_IDN3 NULL
+// pico unique id
 // version
 #define SCPI_IDN4 "01.00"
 

--- a/source/scpi/scpi_user_config.h
+++ b/source/scpi/scpi_user_config.h
@@ -1,6 +1,15 @@
 #ifndef _SCPI_USER_CONFIG_H
 #define _SCPI_USER_CONFIG_H
 
+// here you can override the SCPI lib default response terminator
+/* set the termination character(s)   */
+#ifndef SCPI_LINE_ENDING
+#define LINE_ENDING_CR          "\r"    /*   use a <CR> carriage return as termination charcter */
+#define LINE_ENDING_LF          "\n"    /*   use a <LF> line feed as termination charcter */
+#define LINE_ENDING_CRLF        "\r\n"  /*   use <CR><LF> carriage return + line feed as termination charcters */
+#define SCPI_LINE_ENDING        LINE_ENDING_CRLF
+#endif
+
 // define instrument specific registers
 #define USE_CUSTOM_REGISTERS 1
 


### PR DESCRIPTION
pico unique id is now the serial number part of the scpi identifier string
you can override the SCPI LIB default response terminator (CRLF)
bump PSL version (for the scpi identifier functionality)

closes #86 