### PR TITLE
response terminator now single line feed character

### DIFF
--- a/source/scpi/scpi_user_config.h
+++ b/source/scpi/scpi_user_config.h
@@ -7,7 +7,7 @@
 #define LINE_ENDING_CR          "\r"    /*   use a <CR> carriage return as termination charcter */
 #define LINE_ENDING_LF          "\n"    /*   use a <LF> line feed as termination charcter */
 #define LINE_ENDING_CRLF        "\r\n"  /*   use <CR><LF> carriage return + line feed as termination charcters */
-#define SCPI_LINE_ENDING        LINE_ENDING_CRLF
+#define SCPI_LINE_ENDING        LINE_ENDING_LF
 #endif
 
 // define instrument specific registers

--- a/test/visaQuery.py
+++ b/test/visaQuery.py
@@ -15,7 +15,7 @@ def test_idn():
 	print(idn)
 
 	# check if the IDN string matches the expected pattern. Allow for different serial number
-	if(re.search("PICO-PI,LABTOOL,\d+,01.00\r\n", idn) != None):
+	if(re.search("PICO-PI,LABTOOL,([0-9a-fA-F]+),01.00\n", idn) != None):
 		isPico = (inst.is_4882_compliant)
 
 


### PR DESCRIPTION
scpi response LF instead of CRLF
pyVisa script adapted (tested for the CR,(and also struggled over the new serial number in the identifier
LabVIEW driver tested