### PR TITLE
Added overridable firmware version numbers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,4 +117,6 @@ target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE
         USB_MANUFACTURER=0x01
         USB_PRODUCT=0x02
         USB_SERIALNUMBER=0x03
+        FW_VER_BCD=0x0100
+        FW_VER_STR="01.00"
 )

--- a/source/scpi/scpi-def.h
+++ b/source/scpi/scpi-def.h
@@ -11,7 +11,11 @@
 // serial number
 // pico unique id
 // version
+#ifdef FW_VER_STR
+#define SCPI_IDN4 FW_VER_STR
+#else
 #define SCPI_IDN4 "01.00"
+#endif
 
 extern const scpi_command_t scpi_commands[];
 


### PR DESCRIPTION
This change goes with https://github.com/jancumps/pico_scpi_usbtmc_lablib/pull/12.

This change causes [source/scpi/scpi-def.h](source/scpi/scpi-def.h) to use the macro `FW_VER_STR` as the SCPI device version string, if the macro is defined. Otherwise, it stays with the default of `1.00`.

This change also adds two lines to [CMakeLists.txt](CMakeLists.txt), setting both BCD and string forms of the firmware version. I'd prefer to have one authoritative source of the firmware version, and for it to be set in an included `.h` file. I think you prefer overrides in CMakeLists.txt, so I did it here. The single-source version also requires a bit more preprocessor work. You would probably define the major and minor versions separately as numbers, then combine them arithmetically for the BCD version, and using preprocessor stringification for the string version. My inference is that you prefer this way.

I tested this code in several ways:
1. I built the firmware and ran a simple VISA program against the device. It seems to be fine.
2. I built the firmware in several configuration scenarios and verified that the values came out as expected:
  * No `FW_VER_*` overrides, just the defaults
  * With overrides, set to something different
  * With overrides, set equal to the defaults.

And I think that's about right.

Note: This change is meant to be taken via `rebase`, not `merge`